### PR TITLE
Fix crash when the next next sibling doesn't exist

### DIFF
--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -74,6 +74,7 @@ function inject() {
   [].forEach.call(tokens, function(line) {
     if (line.innerHTML === 'require') {
       var pkgEl = line.nextSibling.nextSibling;
+      if (!pkgEl) return;
       var pkg = pkgEl.innerHTML.match(/span>([^<]+)/);
       if (!pkg || !pkg[1]) return; // continue if we have invalid input
       pkg = pkg[1];


### PR DESCRIPTION
e.g. https://github.com/moznion/gulp-tsd/blob/master/index.js when it's
attempting to link `require(path.resolve(file.path))`.
