### PR TITLE
add package.json support

### DIFF
--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -71,7 +71,7 @@ function registerInjector() {
 function inject() {
   var file = document.querySelector('.final-path');
 
-  if (file.innerHTML === 'package.json') {
+  if (file && file.innerHTML === 'package.json') {
     var tokens = document.querySelectorAll('.blob-code.js-file-line');
     var isPkg = false;
 


### PR DESCRIPTION
Adds links to dependencies in package.json. It sets a package flag when it encounters "dependencies" or "devDependencies" so it can be done in one pass. There isn't much else to look for that wouldn't be trumped by edge cases.

Resolves #1 
