### PR TITLE
add 'require-navigator' class to modified links

### DIFF
--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -75,76 +75,79 @@ function registerInjector() {
 }
 
 function inject() {
+  var modified = document.querySelector('.require-navigator');
   var file = document.querySelector('.final-path');
 
-  if (file && file.innerHTML === 'package.json') {
-    var tokens = document.querySelectorAll('.blob-code.js-file-line');
-    var isPkg = false;
+  if (!modified) {
+    if (file && file.innerHTML === 'package.json') {
+      var tokens = document.querySelectorAll('.blob-code.js-file-line');
+      var isPkg = false;
 
-    [].forEach.call(tokens, function(line) {
-      var pkgEl = line.querySelector('.pl-s1');
+      [].forEach.call(tokens, function(line) {
+        var pkgEl = line.querySelector('.pl-s1');
 
-      if (!pkgEl) {
-        // no inner span means no dependency or end of list
-        isPkg = false;
-        return;
-      }
-
-      if (!isPkg && line.innerText.match(/"(dev)?dependencies"\s*:/i)) {
-        // set isPkg flag if dependency list is found
-        isPkg = true;
-      } else if (isPkg) {
-        var pkg = pkgEl.innerText.replace(/"/g, '');
-        var url = 'http://ghub.io/' + pkg;
-        pkgEl.innerHTML = pkgEl.innerHTML
-          .replace(pkg, '<a class="pl-pds" href="' +
-            url + '">' + pkg + '</a>');
-      }
-    });
-
-  } else {
-    var tokens = document.querySelectorAll('.blob-code.js-file-line .pl-s3');
-
-    [].forEach.call(tokens, function(line) {
-      if (line.innerHTML === 'require') {
-        var pkgEl = line.nextSibling.nextSibling;
-        if (!pkgEl) return;
-        var pkg = pkgEl.innerHTML.match(/span>([^<]+)/);
-        if (!pkg || !pkg[1]) return; // continue if we have invalid input
-        pkg = pkg[1];
-
-        var url;
-        if (pkg.indexOf('.') === 0) {
-          url = pkg;
-
-          // check for lack of extension
-          var regex = /\.\w+$/i;
-          if (!pkg.match(regex)) {
-            // if there's no extension, do a HEAD request on the path
-            // we use a HEAD request so we don't fetch the whole page (faster, less bandwidth)
-            var xhr = new XMLHttpRequest();
-            xhr.open('HEAD', url, false); // would be nice to make this async
-            xhr.onreadystatechange = function () {
-              if (this.readyState === 4) {
-                if (this.status === 404) {
-                  // if it doesn't exist, we'll assume it's a js file
-                  url = pkg + '.js';
-                }
-              }
-            }
-            xhr.send();
-          }
-        } else if (natives.indexOf(pkg) >= 0) {
-          url = 'http://nodejs.org/api/' + pkg + '.html';
-        } else {
-          // split on `/` for cases like `require('foo/bar')`
-          url = 'http://ghub.io/' + pkg.split('/')[0];
+        if (!pkgEl) {
+          // no inner span means no dependency or end of list
+          isPkg = false;
+          return;
         }
 
-        pkgEl.innerHTML = pkgEl.innerHTML
-          .replace(pkg, '<a class="pl-pds" href="' +
-            url + '">' + pkg + '</a>');
-      }
-    });
+        if (!isPkg && line.innerText.match(/"(dev)?dependencies"\s*:/i)) {
+          // set isPkg flag if dependency list is found
+          isPkg = true;
+        } else if (isPkg) {
+          var pkg = pkgEl.innerText.replace(/"/g, '');
+          var url = 'http://ghub.io/' + pkg;
+          pkgEl.innerHTML = pkgEl.innerHTML
+            .replace(pkg, '<a class="pl-pds require-navigator" href="' +
+              url + '">' + pkg + '</a>');
+        }
+      });
+
+    } else {
+      var tokens = document.querySelectorAll('.blob-code.js-file-line .pl-s3');
+
+      [].forEach.call(tokens, function(line) {
+        if (line.innerHTML === 'require') {
+          var pkgEl = line.nextSibling.nextSibling;
+          if (!pkgEl) return;
+          var pkg = pkgEl.innerHTML.match(/span>([^<]+)/);
+          if (!pkg || !pkg[1]) return; // continue if we have invalid input
+          pkg = pkg[1];
+
+          var url;
+          if (pkg.indexOf('.') === 0) {
+            url = pkg;
+
+            // check for lack of extension
+            var regex = /\.\w+$/i;
+            if (!pkg.match(regex)) {
+              // if there's no extension, do a HEAD request on the path
+              // we use a HEAD request so we don't fetch the whole page (faster, less bandwidth)
+              var xhr = new XMLHttpRequest();
+              xhr.open('HEAD', url, false); // would be nice to make this async
+              xhr.onreadystatechange = function () {
+                if (this.readyState === 4) {
+                  if (this.status === 404) {
+                    // if it doesn't exist, we'll assume it's a js file
+                    url = pkg + '.js';
+                  }
+                }
+              }
+              xhr.send();
+            }
+          } else if (natives.indexOf(pkg) >= 0) {
+            url = 'http://nodejs.org/api/' + pkg + '.html';
+          } else {
+            // split on `/` for cases like `require('foo/bar')`
+            url = 'http://ghub.io/' + pkg.split('/')[0];
+          }
+
+          pkgEl.innerHTML = pkgEl.innerHTML
+            .replace(pkg, '<a class="pl-pds require-navigator" href="' +
+              url + '">' + pkg + '</a>');
+        }
+      });
+    }
   }
 }


### PR DESCRIPTION
Links injected into the page are given the `require-navigator` class so the extension doesn't try to inject twice, but also so that anyone inspecting the html will see the source of the modification.

Resolves #12 
