### PR TITLE
Add multiple extension support

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Builder Version</key>
-	<string>10600.1.25</string>
+	<string>10600.7.12</string>
 	<key>CFBundleDisplayName</key>
 	<string>require-navigator</string>
 	<key>CFBundleIdentifier</key>
@@ -15,7 +15,10 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>Chrome</key>
-	<dict/>
+	<dict>
+		<key>Global Page</key>
+		<string>src/safari.html</string>
+	</dict>
 	<key>Content</key>
 	<dict>
 		<key>Scripts</key>

--- a/Settings.plist
+++ b/Settings.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+	<dict>
+		<key>DefaultValue</key>
+		<string>js,json,ts,coffee</string>
+		<key>Key</key>
+		<string>extensions</string>
+		<key>Title</key>
+		<string>Extensions To Test (separate with ,)</string>
+		<key>Type</key>
+		<string>TextField</string>
+	</dict>
+</array>
+</plist>

--- a/src/safari.html
+++ b/src/safari.html
@@ -1,0 +1,19 @@
+<!DOCTYPE HTML>
+<html>
+  <head>
+    <title>require navigator</title>
+    <script type="text/javascript">
+      safari.application.addEventListener("message", function (msgEvent) {
+        if (msgEvent.name === "loaded") {
+          msgEvent.target.page.dispatchMessage("afterLoaded", {
+            settings: {
+              extensions: safari.extension.settings.extensions.split(',').filter(function (ext) { return !!ext; })
+            }
+          });
+        }
+      }, false);
+    </script>
+  </head>
+  <body>
+  </body>
+</html>


### PR DESCRIPTION
Fixes #6

An alternative implementation to #17 that also supports linking between different file types.

When a relative url is discovered without a file extension then a set of HEAD requests are sent to different possible urls to try and discover one that works. In priority order are tried: the extensionless url, the url + the current pages extension, a list of extensions that can be configured by the user.

Configuration support has been added for Safari, should be relatively easy to do something similar for Chrome, I don't have it available to test though.

Test page for current pages extension (coffee):
  https://github.com/cabbagejs/cabbage/blob/master/lib/build-trees.coffee
Test page for across filetypes (js -> coffee):
  https://github.com/cabbagejs/cabbage/blob/master/index.js
